### PR TITLE
Fix Issue 5: allow file name to start with '-'

### DIFF
--- a/ffmpegwrapper/ffmpeg.py
+++ b/ffmpegwrapper/ffmpeg.py
@@ -55,7 +55,7 @@ class Output(ParameterContainer):
         return self
 
     def __iter__(self):
-        return chain(ParameterContainer.__iter__(self), [self.file_path])
+        return chain(ParameterContainer.__iter__(self), ['--', self.file_path])
 
 
 class FFmpegProcess(object):


### PR DESCRIPTION
[Issue 5](https://github.com/interru/ffmpegwrapper/issues/5):  ffmpegwrapper fails to process files which starts with '-'